### PR TITLE
Moving GET trait coloc-pairs to its own endpoint, which uses StreamingResponse

### DIFF
--- a/app/db/coloc_pairs_db.py
+++ b/app/db/coloc_pairs_db.py
@@ -98,3 +98,57 @@ class ColocPairsDBClient:
         rows = cursor.fetchall()
         columns = [d[0] for d in cursor.description] if cursor.description else []
         return rows, columns
+
+    @log_performance
+    def get_coloc_pairs_by_snp_ids_stream(
+        self, snp_ids: List[int], h3_threshold: float = 0.0, h4_threshold: float = 0.8, batch_size: int = 100000
+    ):
+        """
+        Stream coloc pairs in batches to avoid memory issues with large datasets.
+
+        Args:
+            snp_ids: List of SNP IDs to query
+            batch_size: Number of rows to yield at a time
+
+        Yields:
+            JSON strings of coloc pair records
+        """
+        if not snp_ids:
+            return
+
+        placeholders = ",".join(["?"] * len(snp_ids))
+        query = f"""
+            SELECT * FROM coloc_pairs
+            WHERE snp_id IN ({placeholders})
+                AND h3 >= ?
+                AND h4 >= ?
+                AND spurious = FALSE
+            ORDER BY snp_id
+        """
+
+        cursor = self.coloc_pairs_conn.execute(query, snp_ids + [h3_threshold, h4_threshold])
+        columns = [d[0] for d in cursor.description] if cursor.description else []
+
+        # Yield header
+        yield '{"coloc_pairs": ['
+
+        first_batch = True
+        while True:
+            batch = cursor.fetchmany(batch_size)
+            if not batch:
+                break
+
+            for row in batch:
+                if not first_batch:
+                    yield ","
+                else:
+                    first_batch = False
+
+                # Convert row to dict and then to JSON
+                row_dict = dict(zip(columns, row))
+                import json
+
+                yield json.dumps(row_dict)
+
+        # Yield footer
+        yield "]}"

--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -365,7 +365,6 @@ class VariantSearchResponse(BaseModel):
 class TraitResponse(BaseModel):
     trait: Trait | GwasUpload
     coloc_groups: Optional[List[ColocGroup]] | Optional[List[ExtendedUploadColocGroup]] = None
-    coloc_pairs: Optional[List[dict]] = None  # allow raw dict rows to avoid overhead
     rare_results: Optional[List[RareResult]] = None
     study_extractions: Optional[List[ExtendedStudyExtraction]] = None
     upload_study_extractions: Optional[List[UploadStudyExtraction]] = None

--- a/app/services/redis_decorator.py
+++ b/app/services/redis_decorator.py
@@ -24,7 +24,11 @@ def redis_cache(expire: int = 0, prefix: str = "db_cache", model_class: BaseMode
         def wrapper(self, *args, **kwargs):
             redis_client = RedisClient()
             cache_key = f"{prefix}:{func.__name__}"
-            if args or kwargs:
+            cache_id = kwargs.pop("cache_id", None)
+
+            if cache_id:
+                cache_key = f"{cache_key}:{cache_id}"
+            elif args or kwargs:
                 args_str = json.dumps([str(arg) for arg in args], sort_keys=True)
                 kwargs_str = json.dumps(kwargs, sort_keys=True)
                 key_hash = hashlib.md5(f"{args_str}:{kwargs_str}".encode()).hexdigest()[:8]

--- a/tests/integration/test_api/v1/test_traits.py
+++ b/tests/integration/test_api/v1/test_traits.py
@@ -60,3 +60,19 @@ def test_get_trait_by_id_with_associations():
         assert association["study_id"] is not None
         assert association["beta"] is not None
         assert association["se"] is not None
+
+
+def test_get_trait_coloc_pairs():
+    response = client.get("/v1/traits/5020/coloc-pairs")
+    assert response.status_code == 200
+    response_json = response.json()
+    assert response_json is not None
+    coloc_pairs = response_json["coloc_pairs"]
+    assert len(coloc_pairs) > 0
+    for coloc_pair in coloc_pairs:
+        assert coloc_pair["snp_id"] is not None and isinstance(coloc_pair["snp_id"], int)
+        assert coloc_pair["h3"] is not None and isinstance(coloc_pair["h3"], float)
+        assert coloc_pair["h4"] is not None and isinstance(coloc_pair["h4"], float)
+        assert coloc_pair["study_extraction_a_id"] is not None and isinstance(coloc_pair["study_extraction_a_id"], int)
+        assert coloc_pair["study_extraction_b_id"] is not None and isinstance(coloc_pair["study_extraction_b_id"], int)
+        assert coloc_pair["spurious"] is not None and isinstance(coloc_pair["spurious"], bool)


### PR DESCRIPTION
The motive for moving coloc-pairs into it's own endpoint is the size of the payload.

Millions of coloc-pairs in the response meant that the API couldn't handle such a large payload.  Moving it to it's own endpoint and to StreamingResponse significantly lowers the memory footprint of the call.